### PR TITLE
Use correct provider version

### DIFF
--- a/modules/github/versions.tf
+++ b/modules/github/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     github = {
       source  = "integrations/github"
-      version = ">= 6.21, < 7"
+      version = ">= 6.2.1, < 7"
     }
 
     google = {


### PR DESCRIPTION
Fixes provider version for `integrations/github`.

Fixes #5.