### PR TITLE
Add secret data reading capability to secrets module

### DIFF
--- a/modules/secrets/README.md
+++ b/modules/secrets/README.md
@@ -1,0 +1,54 @@
+# Secrets
+
+A module that manages a set of secrets in a project.
+
+## Usage
+
+You can use this module to quickly create a set of secrets, which will be
+assigned a descriptive label in the project by the given topic.
+
+You can optionally provide a list of members which will be given the secret
+accessor role.
+
+For secrets that are to be used later in the Terraform configuration, a map of
+requested secret versions can be optionally supplied to have their secret data
+assigned to the output.
+
+```hcl
+module "my_secrets" {
+  source = "../modules/secrets"
+
+  project = var.project_id
+  topic   = "cloudbuild"
+
+  secret_accessors = [
+    "serviceAccount:my-service-account@my-project.iam.gserviceaccount.com"
+  ]
+
+  read_secret_version = {
+    my-api-token = "latest"
+    my-ssh-key   = "1"
+  }
+}
+
+output "my_api_token" {
+  value = module.my_secrets.secret_data["my-api-token"]
+}
+```
+
+## Inputs
+
+| Name | Type | Description | Default | Required |
+|------|------|-------------|---------|:--------:|
+| project | string | The project ID where secret resources are centralized. | n/a | yes |
+| secrets | list(string) | Descriptive names of secrets to create. | n/a | yes |
+| topic | string | Some descriptive text that will be added to the labels for this set of secrets in the project, e.g. 'cloudbuild'. | n/a | yes |
+| secret_accessors | list(string) | Service accounts given permission to read secrets. | `[]` | no |
+| read_secret_version | map(string) | Map of secrets and the version for which secret data is to be retrieved. For secret data to be read and used in TF configurations. | `{}` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| secret_data | Secret plaintexts. |
+| secret_names | Secret names mapped to their full resource IDs. |

--- a/modules/secrets/main.tf
+++ b/modules/secrets/main.tf
@@ -26,3 +26,11 @@ resource "google_secret_manager_secret_iam_member" "secret_accessors" {
   role      = "roles/secretmanager.secretAccessor"
   secret_id = google_secret_manager_secret.secret[each.value.secret].id
 }
+
+data "google_secret_manager_secret_version" "secret_data" {
+  for_each = var.read_secret_version
+
+  project = google_secret_manager_secret.secret[each.key].project
+  secret  = google_secret_manager_secret.secret[each.key].id
+  version = each.value
+}

--- a/modules/secrets/outputs.tf
+++ b/modules/secrets/outputs.tf
@@ -1,0 +1,15 @@
+output "secret_data" {
+  value = zipmap(
+    keys(data.google_secret_manager_secret_version.secret_data),
+    values(data.google_secret_manager_secret_version.secret_data)[*].secret_data
+  )
+  description = "Secret plaintexts."
+}
+
+output "secret_names" {
+  value = zipmap(
+    values(google_secret_manager_secret.secret)[*].secret_id,
+    values(google_secret_manager_secret.secret)[*].id
+  )
+  description = "Secret names mapped to their full resource IDs."
+}

--- a/modules/secrets/variables.tf
+++ b/modules/secrets/variables.tf
@@ -18,3 +18,9 @@ variable "topic" {
   type        = string
   description = "Some descriptive text that will be added to the labels for this set of secrets in the project, e.g. 'cloudbuild'."
 }
+
+variable "read_secret_version" {
+  type        = map(string)
+  default     = {}
+  description = "Map of secrets and the version for which secret data is to be retrieved. For secret data to be read and used in TF configurations."
+}


### PR DESCRIPTION
## Summary

This PR adds support for reading secret versions in the secrets module.

## Changes

- Added `read_secret_version` variable for specifying which secret versions to read
- Added `google_secret_manager_secret_version` data source for reading secret data
- Added `secret_data` output exposing plaintext secret values
- Added `secret_names` output mapping secret names to resource IDs
- Added `README.md` with usage documentation and examples

## Usage Example

```hcl
module "my_secrets" {
  source = "../modules/secrets"

  project = var.project_id
  topic   = "cloudbuild"

  read_secret_version = {
    my-api-token = "latest"
    my-ssh-key   = "1"
  }
}

output "my_api_token" {
  value = module.my_secrets.secret_data["my-api-token"]
}
```

## Related

This module now supports reading secret versions for use within Terraform configurations, enabling secrets to be consumed directly in HCL.