### PR TITLE
Add CI workflows for Terraform and Prettier

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -1,0 +1,75 @@
+name: Terraform
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  TERRAFORM_VERSION: 1.9.8
+
+jobs:
+  format:
+    name: Terraform fmt
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v4
+        with:
+          terraform_version: ${{ env.TERRAFORM_VERSION }}
+          terraform_wrapper: false
+
+      - name: Check formatting
+        run: terraform fmt -check -recursive -diff
+
+  discover:
+    name: Discover modules
+    runs-on: ubuntu-latest
+    outputs:
+      modules: ${{ steps.list.outputs.modules }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: List modules
+        id: list
+        run: |
+          modules=$(find modules -mindepth 1 -maxdepth 1 -type d -printf '%f\n' | jq -R . | jq -s -c .)
+          echo "modules=$modules" >> "$GITHUB_OUTPUT"
+
+  validate:
+    name: Validate ${{ matrix.module }}
+    runs-on: ubuntu-latest
+    needs:
+      - format
+      - discover
+    strategy:
+      fail-fast: false
+      matrix:
+        module: ${{ fromJson(needs.discover.outputs.modules) }}
+    defaults:
+      run:
+        working-directory: modules/${{ matrix.module }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v4
+        with:
+          terraform_version: ${{ env.TERRAFORM_VERSION }}
+          terraform_wrapper: false
+
+      - name: Initialize
+        run: terraform init -backend=false -input=false
+
+      - name: Validate
+        run: terraform validate -no-color

--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -1,0 +1,13 @@
+name: Workspace
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  check:
+    uses: langri-sha/github/.github/workflows/check.yml@v0.7.2
+    with:
+      prettier: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 .*
 !.editorconfig
+!.github
 !.gitignore
+!.prettierignore
+!.prettierrc.yaml
+node_modules/

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,8 @@
+.terraform/
+*.tf
+*.tfvars
+*.tfstate
+*.tfstate.backup
+.terraform.lock.hcl
+node_modules/
+pnpm-lock.yaml

--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# terraform-google-cloud-platform
+
+A collection of Terraform modules for bootstrapping and managing resources on
+Google Cloud Platform.
+
+## Modules
+
+| Module                                                    | Description                                                                   |
+| --------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| [`access-token-resolver`](modules/access-token-resolver/) | Resolves an access token from a service account.                              |
+| [`cloudbuild`](modules/cloudbuild/)                       | Provisions a Cloud Build project with shared build resources.                 |
+| [`github`](modules/github/)                               | Configures a GitHub repository for keyless authentication and GitHub Actions. |
+| [`org`](modules/org/)                                     | Configures organization-level IAM and policies.                               |
+| [`public-dns`](modules/public-dns/)                       | Manages a public DNS zone.                                                    |
+| [`secrets`](modules/secrets/)                             | Manages a set of secrets in Secret Manager.                                   |
+| [`terraform-admin`](modules/terraform-admin/)             | Bootstraps a project used for Terraform state and administration.             |
+| [`workspace`](modules/workspace/)                         | Configures a Google Workspace project.                                        |

--- a/modules/cloudbuild/main.tf
+++ b/modules/cloudbuild/main.tf
@@ -19,7 +19,7 @@ resource "google_cloudbuild_trigger" "triggers" {
   included_files = each.value.included_files
 
   github {
-    name = var.repo_name
+    name  = var.repo_name
     owner = var.repo_owner
 
     dynamic "pull_request" {

--- a/modules/cloudbuild/outputs.tf
+++ b/modules/cloudbuild/outputs.tf
@@ -1,4 +1,4 @@
 output "service_account_email" {
-  value = google_project_service_identity.cloudbuild.email
+  value       = google_project_service_identity.cloudbuild.email
   description = "Cloud Build service account email for the project."
 }

--- a/modules/github/README.md
+++ b/modules/github/README.md
@@ -1,8 +1,8 @@
 # GitHub
 
 Configures a GitHub repository with resources that are controlled by automation,
-mostly for [enabling keyless authentication] and configuring the [GitHub Actions]
-environment.
+mostly for [enabling keyless authentication] and configuring the [GitHub
+Actions] environment.
 
 ## Usage
 
@@ -41,5 +41,6 @@ module "github" {
 }
 ```
 
-[enabling keyless authentication]: https://cloud.google.com/blog/products/identity-security/enabling-keyless-authentication-from-github-actions
+[enabling keyless authentication]:
+  https://cloud.google.com/blog/products/identity-security/enabling-keyless-authentication-from-github-actions
 [github actions]: https://github.com/features/actions

--- a/modules/org/main.tf
+++ b/modules/org/main.tf
@@ -24,7 +24,7 @@ module "project_org" {
 
 data "google_billing_account" "default" {
   billing_account = var.billing_account
-  open = true
+  open            = true
 
   depends_on = [
     google_organization_iam_binding.billing_creator

--- a/modules/org/outputs.tf
+++ b/modules/org/outputs.tf
@@ -18,7 +18,7 @@ output "domain" {
   value       = data.google_organization.org.domain
 }
 
-output "location"{
+output "location" {
   description = "Default location to use for Google Cloud services."
   value       = var.location
 }

--- a/modules/public-dns/variables.tf
+++ b/modules/public-dns/variables.tf
@@ -15,7 +15,7 @@ variable "project_id" {
 
 variable "mx_records" {
   description = "MX record destinations and their priorities."
-  type = map(number)
+  type        = map(number)
 }
 
 variable "site_verifications" {

--- a/modules/secrets/README.md
+++ b/modules/secrets/README.md
@@ -47,20 +47,20 @@ output "my_api_token" {
 
 ## Inputs
 
-| Name | Type | Description | Default | Required |
-|------|------|-------------|---------|:--------:|
-| project | string | The project ID where secret resources are centralized. | n/a | yes |
-| secrets | list(string) | Descriptive names of secrets to create. | n/a | yes |
-| topic | string | Some descriptive text that will be added to the labels for this set of secrets in the project, e.g. 'cloudbuild'. | n/a | yes |
-| secret_accessors | list(string) | Service accounts given permission to read secrets. | `[]` | no |
-| read_secret_version | map(string) | Map of secrets and the version for which secret data is to be retrieved. For secret data to be read and used in TF configurations. | `{}` | no |
-| write_secret_data | map(string) | Map of secrets and their plaintext data to write as new secret versions. Keys must match entries in `secrets`. | `{}` | no |
-| write_secret_data_base64 | map(string) | Map of secrets and their base64-encoded data to write as new secret versions. Use for binary data like certificates or keys. | `{}` | no |
-| deletion_policy | string | What Terraform does to the prior secret version when it is replaced (e.g. on rotation) or destroyed. One of: `DISABLE`, `DELETE`, `ABANDON`. | `"DISABLE"` | no |
+| Name                     | Type         | Description                                                                                                                                  | Default     | Required |
+| ------------------------ | ------------ | -------------------------------------------------------------------------------------------------------------------------------------------- | ----------- | :------: |
+| project                  | string       | The project ID where secret resources are centralized.                                                                                       | n/a         |   yes    |
+| secrets                  | list(string) | Descriptive names of secrets to create.                                                                                                      | n/a         |   yes    |
+| topic                    | string       | Some descriptive text that will be added to the labels for this set of secrets in the project, e.g. 'cloudbuild'.                            | n/a         |   yes    |
+| secret_accessors         | list(string) | Service accounts given permission to read secrets.                                                                                           | `[]`        |    no    |
+| read_secret_version      | map(string)  | Map of secrets and the version for which secret data is to be retrieved. For secret data to be read and used in TF configurations.           | `{}`        |    no    |
+| write_secret_data        | map(string)  | Map of secrets and their plaintext data to write as new secret versions. Keys must match entries in `secrets`.                               | `{}`        |    no    |
+| write_secret_data_base64 | map(string)  | Map of secrets and their base64-encoded data to write as new secret versions. Use for binary data like certificates or keys.                 | `{}`        |    no    |
+| deletion_policy          | string       | What Terraform does to the prior secret version when it is replaced (e.g. on rotation) or destroyed. One of: `DISABLE`, `DELETE`, `ABANDON`. | `"DISABLE"` |    no    |
 
 ## Outputs
 
-| Name | Description |
-|------|-------------|
-| secret_data | Secret plaintexts. |
+| Name         | Description                                     |
+| ------------ | ----------------------------------------------- |
+| secret_data  | Secret plaintexts.                              |
 | secret_names | Secret names mapped to their full resource IDs. |

--- a/modules/secrets/main.tf
+++ b/modules/secrets/main.tf
@@ -9,7 +9,7 @@ resource "google_secret_manager_secret" "secret" {
   }
 
   replication {
-    automatic = true
+    auto {}
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "terraform-google-cloud-platform",
+  "private": true,
+  "packageManager": "pnpm@10.28.0",
+  "prettier": "@langri-sha/prettier",
+  "devDependencies": {
+    "@langri-sha/prettier": "^0.4.0",
+    "prettier": "^3.8.3",
+    "prettier-plugin-ini": "^1.3.0"
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,54 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      '@langri-sha/prettier':
+        specifier: ^0.4.0
+        version: 0.4.0(prettier@3.8.3)
+      prettier:
+        specifier: ^3.8.3
+        version: 3.8.3
+      prettier-plugin-ini:
+        specifier: ^1.3.0
+        version: 1.3.0
+
+packages:
+
+  '@langri-sha/prettier@0.4.0':
+    resolution: {integrity: sha512-arV4XrK6ZOrQN87iR39dd2B3oXuDTtlQPB2quR0r9S2PKIOy2oi1JT5SipuF3B04f94XDHSbiB3RBG1fXw5WVg==}
+    peerDependencies:
+      prettier: ^3.0.0
+
+  prettier-plugin-ini@1.2.0:
+    resolution: {integrity: sha512-8RR2n3AGlObQ11NCpyvv1N+xkTe/RdGp1vko8xeuXubWUa9NrOEZMX463H1AvnhnUX8b1NeJk3TKFkgvWunApg==}
+
+  prettier-plugin-ini@1.3.0:
+    resolution: {integrity: sha512-kX1KnPwITCTtYV0MTBZQKuFLxcNcbHOS9r7Ta1jHLLvRvZRTzHHqX0MEZMrCkedjLuxpQSgzr4aC5IRd+R3FPw==}
+
+  prettier@3.8.3:
+    resolution: {integrity: sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==}
+    engines: {node: '>=14'}
+    hasBin: true
+
+snapshots:
+
+  '@langri-sha/prettier@0.4.0(prettier@3.8.3)':
+    dependencies:
+      prettier: 3.8.3
+      prettier-plugin-ini: 1.2.0
+
+  prettier-plugin-ini@1.2.0:
+    dependencies:
+      prettier: 3.8.3
+
+  prettier-plugin-ini@1.3.0:
+    dependencies:
+      prettier: 3.8.3
+
+  prettier@3.8.3: {}

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ]
+  "extends": ["config:recommended"]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,14 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"]
+  "extends": ["config:recommended"],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["^\\.github/workflows/terraform\\.yml$"],
+      "matchStrings": ["TERRAFORM_VERSION:\\s*(?<currentValue>\\S+)"],
+      "depNameTemplate": "hashicorp/terraform",
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^v(?<version>.+)$"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

Adds CI that keeps Terraform modules formatted and validated, and reuses the
shared `langri-sha/github` check workflow for Prettier.

## What's in this PR

- `chore: add prettier configuration` — Prettier via pnpm, using the shared
  [`@langri-sha/prettier`](https://github.com/langri-sha/langri-sha.com/tree/main/packages/prettier)
  config. Sets `packageManager` so `pnpm/action-setup` can resolve the version.
- `style: apply prettier formatting to existing files`
- `style: apply terraform fmt to existing modules`
- `fix(secrets): replace deprecated replication.automatic with auto block` —
  restores compatibility with the `google` provider v7.
- `ci: add workspace check workflow` — delegates to
  `langri-sha/github/.github/workflows/check.yml@v0.7.2` with `prettier: true`.
- `ci: add terraform format and validation workflow` — `terraform fmt -check
  -recursive`, a module-discovery step, and a `terraform validate` matrix
  across every module. `TERRAFORM_VERSION` is tracked by a Renovate custom
  regex manager.
- `docs: add readme with module index`

## Test plan

- [x] `Workspace / check / Lint` green (Prettier via shared reusable check)
- [x] `Terraform / Terraform fmt` green
- [x] `Terraform / Discover modules` green
- [x] `Terraform / Validate <module>` matrix green for all 8 modules