### PR TITLE
Add secret data writing capability to secrets module

### DIFF
--- a/modules/secrets/README.md
+++ b/modules/secrets/README.md
@@ -14,12 +14,17 @@ For secrets that are to be used later in the Terraform configuration, a map of
 requested secret versions can be optionally supplied to have their secret data
 assigned to the output.
 
+To populate secrets with values managed by Terraform (for example, outputs from
+another resource), supply `write_secret_data`. Use `write_secret_data_base64`
+for binary payloads. Keys in either map must match entries in `secrets`.
+
 ```hcl
 module "my_secrets" {
   source = "../modules/secrets"
 
   project = var.project_id
   topic   = "cloudbuild"
+  secrets = ["my-api-token", "my-ssh-key", "db-password"]
 
   secret_accessors = [
     "serviceAccount:my-service-account@my-project.iam.gserviceaccount.com"
@@ -28,6 +33,10 @@ module "my_secrets" {
   read_secret_version = {
     my-api-token = "latest"
     my-ssh-key   = "1"
+  }
+
+  write_secret_data = {
+    db-password = random_password.db.result
   }
 }
 
@@ -45,6 +54,9 @@ output "my_api_token" {
 | topic | string | Some descriptive text that will be added to the labels for this set of secrets in the project, e.g. 'cloudbuild'. | n/a | yes |
 | secret_accessors | list(string) | Service accounts given permission to read secrets. | `[]` | no |
 | read_secret_version | map(string) | Map of secrets and the version for which secret data is to be retrieved. For secret data to be read and used in TF configurations. | `{}` | no |
+| write_secret_data | map(string) | Map of secrets and their plaintext data to write as new secret versions. Keys must match entries in `secrets`. | `{}` | no |
+| write_secret_data_base64 | map(string) | Map of secrets and their base64-encoded data to write as new secret versions. Use for binary data like certificates or keys. | `{}` | no |
+| deletion_policy | string | What Terraform does to the prior secret version when it is replaced (e.g. on rotation) or destroyed. One of: `DISABLE`, `DELETE`, `ABANDON`. | `"DISABLE"` | no |
 
 ## Outputs
 

--- a/modules/secrets/main.tf
+++ b/modules/secrets/main.tf
@@ -27,6 +27,27 @@ resource "google_secret_manager_secret_iam_member" "secret_accessors" {
   secret_id = google_secret_manager_secret.secret[each.value.secret].id
 }
 
+resource "google_secret_manager_secret_version" "secret_data" {
+  for_each = {
+    for k, v in var.write_secret_data : k => v if v != ""
+  }
+
+  secret          = google_secret_manager_secret.secret[each.key].id
+  secret_data     = each.value
+  deletion_policy = var.deletion_policy
+}
+
+resource "google_secret_manager_secret_version" "secret_data_base64" {
+  for_each = {
+    for k, v in var.write_secret_data_base64 : k => v if v != ""
+  }
+
+  secret                = google_secret_manager_secret.secret[each.key].id
+  secret_data           = each.value
+  is_secret_data_base64 = true
+  deletion_policy       = var.deletion_policy
+}
+
 data "google_secret_manager_secret_version" "secret_data" {
   for_each = var.read_secret_version
 

--- a/modules/secrets/variables.tf
+++ b/modules/secrets/variables.tf
@@ -24,3 +24,27 @@ variable "read_secret_version" {
   default     = {}
   description = "Map of secrets and the version for which secret data is to be retrieved. For secret data to be read and used in TF configurations."
 }
+
+variable "write_secret_data" {
+  type        = map(string)
+  default     = {}
+  sensitive   = true
+  description = "Map of secrets and their plaintext data to write as new secret versions. Keys must match entries in `secrets`."
+}
+
+variable "write_secret_data_base64" {
+  type        = map(string)
+  default     = {}
+  sensitive   = true
+  description = "Map of secrets and their base64-encoded data to write as new secret versions. Use for binary data like certificates or keys. Keys must match entries in `secrets`."
+}
+
+variable "deletion_policy" {
+  type        = string
+  default     = "DISABLE"
+  description = "What Terraform does to the prior secret version when it is replaced (e.g. on rotation) or destroyed. DISABLE (default) keeps the version but marks it disabled so stale consumers fail loudly and rollback is possible. DELETE permanently destroys it. ABANDON drops it from Terraform state and leaves it enabled."
+  validation {
+    condition     = contains(["DELETE", "DISABLE", "ABANDON"], var.deletion_policy)
+    error_message = "deletion_policy must be one of: DELETE, DISABLE, ABANDON."
+  }
+}


### PR DESCRIPTION
## Summary

Extends `modules/secrets` with support for writing secret versions from Terraform, closing out the write-side counterpart to the existing read capability.

## Changes

- `write_secret_data` — map of plaintext payloads to write as new versions (sensitive).
- `write_secret_data_base64` — map of base64-encoded payloads for binary data (sensitive).
- `deletion_policy` — controls what happens to the prior version on replacement (e.g. rotation) or destroy. Defaults to `DISABLE` so rotations keep history and fail stale consumers loudly; `DELETE` and `ABANDON` are also supported.
- Empty-string entries in either write map are skipped, so callers can conditionally populate values.
- README updated with new inputs and a usage example.

## Test plan

- [ ] \`terraform init\` and \`terraform validate\` pass in a consumer that exercises \`write_secret_data\`.
- [ ] Rotating a value (changing \`write_secret_data[k]\`) creates a new version and disables the previous one.
- [ ] Setting \`deletion_policy = \"DELETE\"\` restores destructive replacement for callers who want it.

Closes #1016