### PR TITLE
fix(secrets): avoid sensitive values in for_each for Terraform 1.14

### DIFF
--- a/modules/secrets/main.tf
+++ b/modules/secrets/main.tf
@@ -28,22 +28,22 @@ resource "google_secret_manager_secret_iam_member" "secret_accessors" {
 }
 
 resource "google_secret_manager_secret_version" "secret_data" {
-  for_each = {
-    for k, v in var.write_secret_data : k => v if v != ""
-  }
+  for_each = toset(nonsensitive([
+    for k, v in var.write_secret_data : k if v != ""
+  ]))
 
   secret          = google_secret_manager_secret.secret[each.key].id
-  secret_data     = each.value
+  secret_data     = var.write_secret_data[each.key]
   deletion_policy = var.deletion_policy
 }
 
 resource "google_secret_manager_secret_version" "secret_data_base64" {
-  for_each = {
-    for k, v in var.write_secret_data_base64 : k => v if v != ""
-  }
+  for_each = toset(nonsensitive([
+    for k, v in var.write_secret_data_base64 : k if v != ""
+  ]))
 
   secret                = google_secret_manager_secret.secret[each.key].id
-  secret_data           = each.value
+  secret_data           = var.write_secret_data_base64[each.key]
   is_secret_data_base64 = true
   deletion_policy       = var.deletion_policy
 }


### PR DESCRIPTION
## Summary

Terraform 1.14 tightened validation and now rejects `for_each` arguments derived from sensitive values. The `secrets` module iterated `var.write_secret_data` and `var.write_secret_data_base64` directly — both are sensitive maps — which broke `terraform validate` on the Renovate upgrade PR.

## Changes

- Drive `for_each` from `toset(nonsensitive([for k, v in … : k if v != ""]))` so only the (already public) secret identifiers are used as resource keys.
- Look up the sensitive value via `var.write_secret_data[each.key]` / `var.write_secret_data_base64[each.key]` so the plaintext retains its `sensitive` marking in plan/state.

Keys must already match entries in `var.secrets` (a non-sensitive `list(string)`) per the variable contract, so stripping sensitivity from the key set is safe — the actual secret material stays sensitive.

## Test plan

- [x] `terraform init -backend=false && terraform validate` in `modules/secrets` under Terraform 1.14.8
- [ ] CI validation passes on this PR
- [ ] Rebase / re-run the Renovate Terraform 1.14 upgrade PR (#25) once this lands

Closes #27