### PR TITLE
feat(github): enhance Workload Identity Federation support

### DIFF
--- a/modules/github/main.tf
+++ b/modules/github/main.tf
@@ -98,9 +98,10 @@ module "github_actions_workload_identity_federation" {
   source  = "terraform-google-modules/github-actions-runners/google//modules/gh-oidc"
   version = ">= 3.1.0"
 
-  project_id  = var.project
-  pool_id     = "github-actions-${random_id.pool_id.hex}"
-  provider_id = "github-provider-${random_id.pool_id.hex}"
+  project_id          = var.project
+  pool_id             = "github-actions-${random_id.pool_id.hex}"
+  provider_id         = "github-provider-${random_id.pool_id.hex}"
+  attribute_condition = var.attribute_condition
   sa_mapping = {
     "github-actions" = {
       sa_name   = google_service_account.github_actions.id

--- a/modules/github/main.tf
+++ b/modules/github/main.tf
@@ -90,6 +90,14 @@ resource "google_service_account" "github_actions" {
   project      = var.project
 }
 
+resource "google_service_account_iam_member" "github_actions_token_creator" {
+  count = var.enable_token_creator ? 1 : 0
+
+  service_account_id = google_service_account.github_actions.id
+  role               = "roles/iam.serviceAccountTokenCreator"
+  member             = "serviceAccount:${google_service_account.github_actions.email}"
+}
+
 resource "random_id" "pool_id" {
   byte_length = 8
 }

--- a/modules/github/main.tf
+++ b/modules/github/main.tf
@@ -102,6 +102,7 @@ module "github_actions_workload_identity_federation" {
   pool_id             = "github-actions-${random_id.pool_id.hex}"
   provider_id         = "github-provider-${random_id.pool_id.hex}"
   attribute_condition = var.attribute_condition
+  attribute_mapping   = var.attribute_mapping
   sa_mapping = {
     "github-actions" = {
       sa_name   = google_service_account.github_actions.id

--- a/modules/github/outputs.tf
+++ b/modules/github/outputs.tf
@@ -12,3 +12,8 @@ output "workload_identity_provider" {
   value       = module.github_actions_workload_identity_federation.provider_name
   description = "GitHub Actions workload identity provider."
 }
+
+output "workload_identity_pool_name" {
+  value       = module.github_actions_workload_identity_federation.pool_name
+  description = "Full resource name of the Workload Identity Pool backing GitHub Actions authentication."
+}

--- a/modules/github/variables.tf
+++ b/modules/github/variables.tf
@@ -8,6 +8,12 @@ variable "actions_secrets" {
   description = "Repository environment secrets to set for GitHub Actions."
 }
 
+variable "attribute_condition" {
+  type        = string
+  default     = null
+  description = "CEL expression that restricts which tokens can authenticate against the Workload Identity Pool provider (e.g., `assertion.repository_owner == 'my-org'`). When null, all tokens from the GitHub OIDC issuer are accepted and access is gated solely by the service account IAM bindings."
+}
+
 variable "deploy_key" {
   type = map(object({
     read_only = bool

--- a/modules/github/variables.tf
+++ b/modules/github/variables.tf
@@ -14,6 +14,17 @@ variable "attribute_condition" {
   description = "CEL expression that restricts which tokens can authenticate against the Workload Identity Pool provider (e.g., `assertion.repository_owner == 'my-org'`). When null, all tokens from the GitHub OIDC issuer are accepted and access is gated solely by the service account IAM bindings."
 }
 
+variable "attribute_mapping" {
+  type = map(string)
+  default = {
+    "google.subject"       = "assertion.sub"
+    "attribute.actor"      = "assertion.actor"
+    "attribute.aud"        = "assertion.aud"
+    "attribute.repository" = "assertion.repository"
+  }
+  description = "Claim mapping from the GitHub OIDC token to Google Workload Identity attributes. Override to surface additional claims (e.g., `attribute.environment`, `attribute.ref`, `attribute.job_workflow_ref`) for use in IAM conditions."
+}
+
 variable "deploy_key" {
   type = map(object({
     read_only = bool

--- a/modules/github/variables.tf
+++ b/modules/github/variables.tf
@@ -25,6 +25,12 @@ variable "attribute_mapping" {
   description = "Claim mapping from the GitHub OIDC token to Google Workload Identity attributes. Override to surface additional claims (e.g., `attribute.environment`, `attribute.ref`, `attribute.job_workflow_ref`) for use in IAM conditions."
 }
 
+variable "enable_token_creator" {
+  type        = bool
+  default     = false
+  description = "Grants the GitHub Actions service account `roles/iam.serviceAccountTokenCreator` on itself, allowing workflows to mint short-lived OAuth access tokens or ID tokens via `iam.generateAccessToken` / `iam.generateIdToken` after federating."
+}
+
 variable "deploy_key" {
   type = map(object({
     read_only = bool


### PR DESCRIPTION
## Summary

Enhances the `modules/github` wrapper around `terraform-google-modules/github-actions-runners//modules/gh-oidc` to expose more of the underlying Workload Identity Federation surface, so callers can tighten security and support impersonation flows without forking the module.

All changes are **additive and backwards-compatible** — new inputs default to values that preserve existing behavior.

### Changes (one per commit)

- **`attribute_condition`** — CEL expression passed to the WIF provider. Lets callers gate token acceptance at the provider level (e.g. restrict to an org, a protected ref, or a specific workflow), in addition to the existing `sa_mapping` attribute check.
- **`attribute_mapping`** — customizable claim mapping. Defaults mirror the upstream `gh-oidc` defaults; overriding lets callers surface additional claims (`environment`, `ref`, `job_workflow_ref`) for use in IAM conditions.
- **`enable_token_creator`** — optional `roles/iam.serviceAccountTokenCreator` self-grant on the GitHub Actions service account, for workflows that need to mint short-lived OAuth access tokens or ID tokens via `iam.generateAccessToken` / `iam.generateIdToken`. Off by default.
- **`workload_identity_pool_name` output** — exposes the underlying WIP resource name so callers can attach additional `sa_mapping`s, IAM bindings, or attribute conditions externally.

## Test plan

- [x] `terraform fmt -check -recursive -diff`
- [x] `terraform validate` against `modules/github`
- [ ] CI: Terraform format + validate workflow green