### PR TITLE
chore(deps): update langri-sha/github action to v0.13.1

### DIFF
--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   check:
-    uses: langri-sha/github/.github/workflows/check.yml@v0.12.0
+    uses: langri-sha/github/.github/workflows/check.yml@v0.13.1
     with:
       prettier: true
       projen: true


### PR DESCRIPTION
## Summary
- Bumps the shared `check.yml` reusable workflow reference in `.github/workflows/workspace.yml` from `v0.12.0` to `v0.13.1` (latest [langri-sha/github](https://github.com/langri-sha/github) release).
- No other workflow in this repo references `langri-sha/github` — `.github/workflows/terraform.yml` calls `hashicorp/setup-terraform@v4` directly and is untouched.

## Safety checks
- **`.github/workflows/workspace.yml` is not projen-generated.** It's absent from `.projen/files.json` and `.gitattributes`' `linguist-generated` list, and `npx projen` (run locally against this branch) left it untouched aside from this edit — confirmed by re-running synth after the change and diffing.
- **`actions/pnpm`'s removed `always-auth` input (`langri-sha/github#88`, commit `c213499`) does not affect this repo.** Neither this repo nor the reusable `check.yml` workflow it calls passes `always-auth` to `actions/pnpm` — `check.yml`'s three "Setup PNPM" steps call the action with no `with:` block at all, in both v0.12.0 and v0.13.1. Nothing to drop.
- **Diffed `check.yml` between v0.12.0 and v0.13.1 directly**: the only change is `check.yml`'s own internal `actions/pnpm` pin moving from `v0.11.0` to `v0.12.0`. No new required inputs/secrets, no interface changes — this repo's existing `with: {prettier, projen, typescript}` / `secrets: inherit` block needs no changes.
- `actions/terraform` changes in this release don't apply — this repo doesn't use that action.

## Worth noting (out of scope, not changed here)
`env.TERRAFORM_VERSION` in `.github/workflows/terraform.yml` is pinned to `1.15.8`. All 8 modules' `versions.tf` set `required_version = ">= 1.3.6"`. These aren't in conflict today — `1.15.8` satisfies the `>= 1.3.6` floor — but:
- The floor hasn't moved since inception while `TERRAFORM_VERSION` has been bumped many times, so it no longer expresses any real minimum-tested version.
- `renovate.json5`'s custom manager only targets `TERRAFORM_VERSION` in `terraform.yml`; nothing keeps `required_version` in sync with it.
- This is a milder variant of the class of drift bug behind `langri-sha/github-repos#3`, where `required_version` is pinned to an *exact* version (`"1.15.8"`) instead of a floor, and desynced from the CI-installed Terraform (`1.15.7`), hard-failing `terraform init` with "Unsupported Terraform Core version". This repo's `>=` floor makes it structurally safer, but may still be worth its own issue if an exact pin is ever introduced here.

Not fixed in this PR per scope.