### PR TITLE
Exclude our own packages from the release-age gates

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -46,6 +46,11 @@ const project = new Project({
         groupSlug: 'langri-sha-projen',
         matchSourceUrls: ['https://github.com/langri-sha/projen'],
       },
+      {
+        description: 'Install our own packages without waiting them out',
+        matchPackageNames: ['@langri-sha/**'],
+        minimumReleaseAge: null,
+      },
     ],
     customManagers: [
       {
@@ -80,26 +85,7 @@ new YamlFile(project, 'pnpm-workspace.yaml', {
       '@swc/core': false,
       esbuild: false,
     },
-    minimumReleaseAgeExclude: [
-      '@langri-sha/projen-babel@0.5.3',
-      '@langri-sha/projen-beachball@0.5.5',
-      '@langri-sha/projen-codeowners@0.5.5',
-      '@langri-sha/projen-editorconfig@0.6.5',
-      '@langri-sha/projen-eslint@0.3.6',
-      '@langri-sha/projen-husky@0.3.13',
-      '@langri-sha/projen-jest-config@0.4.6',
-      '@langri-sha/projen-license@0.3.8',
-      '@langri-sha/projen-lint-staged@0.3.7',
-      '@langri-sha/projen-lint-synthesized@0.5.7',
-      '@langri-sha/projen-pnpm-workspace@0.3.6',
-      '@langri-sha/projen-prettier@0.4.6',
-      '@langri-sha/projen-project@0.21.0',
-      '@langri-sha/projen-readme@0.1.5',
-      '@langri-sha/projen-renovate@0.4.10',
-      '@langri-sha/projen-swcrc@0.1.10',
-      '@langri-sha/projen-typescript-config@0.5.11',
-      '@langri-sha/tsconfig@1.0.0',
-    ],
+    minimumReleaseAgeExclude: ['@langri-sha/*'],
   },
 })
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,21 +4,4 @@ allowBuilds:
   '@swc/core': false
   esbuild: false
 minimumReleaseAgeExclude:
-  - '@langri-sha/projen-babel@0.5.3'
-  - '@langri-sha/projen-beachball@0.5.5'
-  - '@langri-sha/projen-codeowners@0.5.5'
-  - '@langri-sha/projen-editorconfig@0.6.5'
-  - '@langri-sha/projen-eslint@0.3.6'
-  - '@langri-sha/projen-husky@0.3.13'
-  - '@langri-sha/projen-jest-config@0.4.6'
-  - '@langri-sha/projen-license@0.3.8'
-  - '@langri-sha/projen-lint-staged@0.3.7'
-  - '@langri-sha/projen-lint-synthesized@0.5.7'
-  - '@langri-sha/projen-pnpm-workspace@0.3.6'
-  - '@langri-sha/projen-prettier@0.4.6'
-  - '@langri-sha/projen-project@0.21.0'
-  - '@langri-sha/projen-readme@0.1.5'
-  - '@langri-sha/projen-renovate@0.4.10'
-  - '@langri-sha/projen-swcrc@0.1.10'
-  - '@langri-sha/projen-typescript-config@0.5.11'
-  - '@langri-sha/tsconfig@1.0.0'
+  - '@langri-sha/*'

--- a/renovate.json5
+++ b/renovate.json5
@@ -25,6 +25,11 @@
       groupSlug: 'langri-sha-projen',
       matchSourceUrls: ['https://github.com/langri-sha/projen'],
     },
+    {
+      description: 'Install our own packages without waiting them out',
+      matchPackageNames: ['@langri-sha/**'],
+      minimumReleaseAge: null,
+    },
   ],
   customManagers: [
     {


### PR DESCRIPTION
## Summary

pnpm holds back dependencies published in the last 24 hours, and since langri-sha/projen#63 Renovate waits three days before proposing one. Neither window does useful work for packages we publish ourselves — we are the supply chain being guarded against, so the delay only stops us installing our own releases.

Replaces the pinned `minimumReleaseAgeExclude` list with the `@langri-sha/*` glob, and adds the matching Renovate rule.

Closes langri-sha/projen#85.

## Why the pinned list had to go

It listed 18 `name@version` entries. Every release of the projen monorepo invalidated all of them — installing one new package meant rewriting the whole list, and until someone did, the exclusion silently stopped covering anything it hadn't been updated for.

That is not hypothetical here: the list pins `@langri-sha/projen-project@0.21.0`, so it does not cover `0.22.0`, published today. #40 (`update langri-sha projen toolchain`) is the PR that wants exactly that version.

## Verified, not assumed

pnpm has two enforcement paths, and they behave differently:

- **Resolution** — `minimumReleaseAgeStrict` defaults to `false`, so when no version in range meets the age constraint, pnpm installs the newest anyway.
- **Lockfile verification** — `ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION`, which fails by default. This is the CI path, on `--frozen-lockfile` against a lockfile Renovate produced, and it is what turned `main` red twice.

Control/treatment against real pnpm 11.17.0 with genuinely too-fresh packages, under `minimumReleaseAgeStrict: true`:

| Config | Result |
| --- | --- |
| no exclude | `ERR_PNPM_NO_MATURE_MATCHING_VERSION` — 17 packages rejected |
| `minimumReleaseAgeExclude: ['@langri-sha/*']` | installs `@langri-sha/projen-project@0.22.0` cleanly |

pnpm compiles the `*` to `.*` (not path-aware), so `@langri-sha/*` matches `@langri-sha/projen-project`, `@langri-sha/tsconfig` and `@langri-sha/prettier`, and does not match `projen` or `@other/pkg`.

## The Renovate half

`matchPackageNames: ['@langri-sha/**']` with `minimumReleaseAge: null`. `@scope/**` is Renovate's documented idiom for "any package starting with the scope".

This has **no effect yet** — this repository is on `@langri-sha/projen-project@^0.21.0`, which predates the three-day default, so its `renovate.json5` has no `minimumReleaseAge` to override. It takes effect the moment the toolchain reaches 0.22.0.

It is included anyway because the two settings have to move together. Exempting our packages on one side while the other still holds them back is precisely what made Renovate propose updates that `pnpm install` then refused. Adding it now means the 0.22.0 upgrade lands without reintroducing that.

## Scope

Only the exclusion. Deliberately does not bump `@langri-sha/projen-project` — Renovate will propose that in #40, and this change is what lets it install.

## Test plan

- `pnpm exec projen` run twice — second is a no-op, confirming idempotent synthesis.
- `tsc --noEmit` and `prettier --check .` — clean.
- Generated `pnpm-workspace.yaml` and `renovate.json5` reviewed by hand: 18 entries collapse to one glob, one Renovate rule added, nothing else changed.
