### PR TITLE
Exempt our own GitHub Actions from minimumReleaseAge

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -51,6 +51,12 @@ const project = new Project({
         matchPackageNames: ['@langri-sha/**'],
         minimumReleaseAge: null,
       },
+      {
+        description:
+          'Install our own GitHub Actions and Terraform modules without waiting them out',
+        matchPackageNames: ['langri-sha/**'],
+        minimumReleaseAge: null,
+      },
     ],
     customManagers: [
       {

--- a/renovate.json5
+++ b/renovate.json5
@@ -31,6 +31,11 @@
       matchPackageNames: ['@langri-sha/**'],
       minimumReleaseAge: null,
     },
+    {
+      description: 'Install our own GitHub Actions and Terraform modules without waiting them out',
+      matchPackageNames: ['langri-sha/**'],
+      minimumReleaseAge: null,
+    },
   ],
   customManagers: [
     {


### PR DESCRIPTION
## Summary

`matchPackageNames: ['@langri-sha/**']` in this repo's Renovate config only
covers our npm scope. GitHub Actions packageNames are bare `owner/repo`
(e.g. `langri-sha/github`), with no `@` prefix, so the existing rule never
matched them — bumps of our own reusable workflow/composite actions waited
out the full 3-day `minimumReleaseAge` for no reason.

Adds a second `packageRules` entry, `matchPackageNames: ['langri-sha/**']`,
right after the existing npm-scope rule, mirroring the exemption added for
npm packages in langri-sha/projen#85.

## Verification

- Verified with `minimatch` (what Renovate uses for `matchPackageNames`)
  that `langri-sha/**` matches `langri-sha/github` and does not match
  `actions/checkout`, `hashicorp/setup-terraform`, or `@langri-sha/prettier`.
- `pnpm exec projen` run twice — byte-identical output, confirming
  idempotency.
- `npx prettier --check .` passes.
- `npx tsc --noEmit` passes.
- Only `.projenrc.ts` and the generated `renovate.json5` changed — no `.tf`
  files touched, so the Terraform validation jobs are unaffected.

This is a per-repo hand-edit rather than a shared projen default: the
exemption is specific to this org and must not leak into
`@langri-sha/projen-project`'s defaults, which unrelated consumers depend on.

Closes #53