### PR TITLE
Build the PNPM workspace through the preset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,6 @@ node_modules/
 !/CODEOWNERS
 !/.editorconfig
 !/license
-!/renovate.json5
 !/pnpm-workspace.yaml
+!/renovate.json5
 !/.projenrc.ts

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -1,5 +1,4 @@
 import { Project } from '@langri-sha/projen-project'
-import { YamlFile } from 'projen'
 
 const project = new Project({
   name: 'terraform-google-cloud-platform',
@@ -37,6 +36,9 @@ const project = new Project({
   },
   editorConfig: {},
   lintSynthesized: {},
+  pnpmWorkspace: {
+    minimumReleaseAgeExclude: ['@langri-sha/*'],
+  },
   prettier: {},
   renovate: {
     packageRules: [
@@ -82,18 +84,5 @@ project.package?.addField('packageManager', 'pnpm@11.19.0')
 project.package?.addField('private', true)
 
 project.tryFindObjectFile('package.json')?.addDeletionOverride('pnpm')
-
-new YamlFile(project, 'pnpm-workspace.yaml', {
-  readonly: true,
-  marker: true,
-  obj: {
-    allowBuilds: {
-      '@swc/core': false,
-      esbuild: false,
-      'unrs-resolver': false,
-    },
-    minimumReleaseAgeExclude: ['@langri-sha/*'],
-  },
-})
 
 project.synth()

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,3 +6,4 @@ allowBuilds:
   unrs-resolver: false
 minimumReleaseAgeExclude:
   - '@langri-sha/*'
+packages: []


### PR DESCRIPTION
This repository built `pnpm-workspace.yaml` by hand as a `YamlFile`, which overrode whatever the preset generated. So `projen-project@0.26.0`'s `allowBuilds` defaults never reached it, and the entries had to be repeated locally — including the `unrs-resolver: false` added in #62 an hour ago.

Switching to the `pnpmWorkspace` option makes the defaults apply. They match what was written by hand exactly: `@swc/core` follows `swcrc` (off here), and `esbuild` and `unrs-resolver` both default to `false`. Only `minimumReleaseAgeExclude` remains to declare.

The generated file is byte-identical apart from a `packages: []` line the component always emits, which the rest of the fleet already has. `.gitignore` picks up a reorder of two existing entries.

Without this, a fleet-wide cleanup dropping the now-redundant `allowBuilds` declarations would silently strip them here — the values would vanish rather than fall back to the preset, and cold installs would start failing again.

Verified: synth idempotent, generated `allowBuilds` unchanged, a clean `pnpm install --frozen-lockfile` from a deleted `node_modules` exits 0, prettier and `tsc --build` pass.